### PR TITLE
Added writer info support to post frontmatter. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# blog
-Blogging on OpenSDS go here
+# OpenSDS Blog
+
+This is the OpenSDS blog repository.  
+
+This website is being run as a Hugo generated website hosted on Netlify.  
+
+We use the _Nederburg theme for Hugo_ from [here](https://github.com/appernetic/hugo-nederburg-theme)  
+
+To become a regular contributor add yourself to the Authors list by following the guide here.  
+
+To contribute follow the _How to Contribute a Blog_ guide.  
+

--- a/config.toml
+++ b/config.toml
@@ -63,6 +63,10 @@ paginate = 5 #frontpage pagination
   # url = "about/"
   # weight = 2
 
+  [[menu.main]]
+   name = "Categories"
+   url = "categories/"
+   weight = 2
 
   # [[menu.main]]
   # name = "Get in touch"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,353 @@
+{{ define "body" }}
+
+<body class="post-template-default single single-post single-format-standard ct-body singular singular-post not-front standard">
+{{ end }}
+
+
+{{ define "main" }}
+  {{ $scratch := newScratch }}
+  {{ if .Site.Params.writers }}
+    {{ $scratch.Set "writer" (index .Site.Params.writers (lower .Params.writer) | default dict) }}
+  {{ else }}
+    {{ $scratch.Set "writer" (.Site.Params.social | default dict) }}
+  {{ end }}
+  {{ $writer := $scratch.Get "writer" }}
+  <div id="loop-container" class="loop-container">
+    {{ if and (isset .Params "image") .Params.image }}
+    <div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-design tag-standard-2 tag-tagalicious tag-travel entry full-without-featured odd excerpt-1">
+
+      <div class='featured-image lazy lazy-bg-image' {{ if isset .Site.Params "usepostimgfolder" }} data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }} data-background="{{ .Params.image | absURL }}"{{ end }}>
+      </div>
+      {{ else }}
+
+      <div class="post type-post status-publish format-standard hentry category-standard category-travel entry full-without-featured odd excerpt-1">
+
+        {{ end }}
+        <div class="entry-meta">
+          <span class="date">{{ .Date.Format "02 January" }}</span>	<span> / </span>
+
+          <span class="author">
+            <a target="_blank" href="{{ .Params.writerLink | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
+          </span>
+
+
+          {{ range .Params.categories }}
+          <span class="category">
+            <span> / </span>
+
+            <a href="/categories/{{ . | urlize }}">{{ . }}</a>
+          </span>
+          {{ end }}
+
+
+        </div>
+        <div class='entry-header'>
+          <h1 class='entry-title'> {{ .Title }}</h1>
+        </div>
+        <div class="entry-container">
+          <div class="entry-content">
+            <article>
+              {{ .Content }}
+            </article>
+          </div>
+          <!--  <div class="sidebar sidebar-after-post-content" id="sidebar-after-post-content">
+          <section id="text-2" class="widget widget_text"><h2 class="widget-title">After Post Content Widget</h2>			<div class="textwidget"><p>This is a widget in the "After Post Content" widget area. It's a great place to include related posts or an email optin form.</p>
+        </div>
+      </section>	</div>-->
+      <div class='entry-meta-bottom'>
+        <!--<nav class="further-reading">
+        <p class="prev">
+        <span>Previous Post</span>
+        <a href="https://www.competethemes.com/tracks-live-demo/another-awesome-post/">Another Awesome Post</a>
+      </p>
+      <p class="next">
+      <span>No Newer Posts</span>
+      <a href="https://www.competethemes.com/tracks-live-demo">Return to Blog</a>
+    </p>
+  </nav>-->
+
+  <div class="entry-categories"><p><span>Categories</span>
+    {{ range $index, $name := .Params.categories }}
+    <a href="{{ "/categories/" | relLangURL }}{{ $name | urlize }}" title="View all posts in {{ $name }}">{{ $name }}</a>{{ end }}
+  </p>
+</div>
+
+
+
+<div class="entry-tags"><p><span>Tags</span>
+  {{ range $index, $name := .Params.tags }}
+  <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}" title="View all posts tagged {{ $name }}">{{ $name }}</a>
+  {{ end }}
+
+</p></div>	</div>
+
+	{{ if and (isset .Site.Params "author") .Site.Params.author }}
+<div class="author-meta">
+
+  <div class="author">
+    {{ if and (isset .Params "writer") .Params.writerEmail }}
+      <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 .Params.writerEmail }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
+    {{ else if and (isset .Params "writer") $writer.email }}
+    <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 $writer.email }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
+    {{ else }}
+      <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 .Site.Params.email }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
+    {{ end }}
+    <span>
+      Written by:<a target="_blank" href="{{ .Params.writerLink | default .Site.Params.authorlink | absURL}}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a> </span>
+    </div>
+    <div class="bio">
+      {{ if and (isset .Params "writer") .Params.writerBio }}
+        <p>{{ .Params.writerBio | default "" | safeHTML }}</p>
+      {{ else if and (isset .Params "writer") $writer.bio }}
+      {{ range $writer.bio  }}
+      <p>{{ . | default "" | safeHTML }}</p>
+        {{ end }}
+      {{ else }}
+      {{ range .Site.Params.bio  }}
+      <p>{{ . | default "" | safeHTML }}</p>
+      {{ end }}
+      {{ end }}
+  {{ if isset .Params "writer" }}
+    {{ if .Params.writerFacebook }}
+      <a class="facebook" target="_blank"
+      href="{{ .Params.writerFacebook }}">
+      <i class="fab fa-facebook-f"
+      title="facebook icon"></i>
+      </a>
+    {{ else if $writer.facebook }}
+      <a class="facebook" target="_blank"
+      href="{{ $writer.facebook }}">
+      <i class="fab fa-facebook-f"
+      title="facebook icon"></i>
+    </a>
+    {{end}}
+
+    {{ if .Params.writerGoogleplus }}
+    <a class="googleplus" target="_blank"
+    href="{{ .Params.writerGoogleplus }}">
+    <i class="fab fa-google-plus-g"
+    title="googleplus icon"></i>
+    </a>
+    {{ else if $writer.googleplus }}
+    <a class="googleplus" target="_blank"
+    href="{{ $writer.googleplus }}">
+    <i class="fab fa-google-plus-g"
+    title="googleplus icon"></i>
+    </a>
+    {{end}}
+
+  {{ if .Params.writerTwitter }}
+    <a class="twitter" target="_blank"
+    href="{{ .Params.writerTwitter }}">
+    <i class="fab fa-twitter-square"
+    title="twitter icon"></i>
+  </a>
+  {{ else if $writer.twitter }}
+  <a class="twitter" target="_blank"
+  href="{{ $writer.twitter }}">
+  <i class="fab fa-twitter-square"
+  title="twitter icon"></i>
+</a>
+{{end}}
+{{ if .Params.writerLinkedin }}
+<a class="linkedin" target="_blank"
+href="{{ .Params.writerLinkedin }}">
+<i class="fab fa-linkedin"
+title="linkedin icon"></i>
+</a>
+{{ else if  $writer.linkedin }}
+<a class="linkedin" target="_blank"
+href="{{ $writer.linkedin }}">
+<i class="fab fa-linkedin"
+title="linkedin icon"></i>
+</a>
+{{end}}
+
+{{ if .Params.writerEmail }}
+<a class="email" target="_blank"
+href="mailto:{{ .Params.writerEmail }}">
+<i class="fas fa-envelope"
+title="email icon"></i>
+</a>
+{{ else if $writer.email }}
+<a class="email" target="_blank"
+href="mailto:{{ $writer.email }}">
+<i class="fas fa-envelope"
+title="email icon"></i>
+</a>
+{{end}}
+
+{{ if .Params.writerInstagram }}
+<a class="instagram" target="_blank"
+href="{{ .Params.writerInstagram }}">
+<i class="fab fa-instagram"
+title="instagram icon"></i>
+</a>
+{{ else if $writer.instagram }}
+<a class="instagram" target="_blank"
+href="{{ $writer.instagram }}">
+<i class="fab fa-instagram"
+title="instagram icon"></i>
+</a>
+{{end}}
+
+{{ if .Params.writerStackoverflow }}
+<a class="stackoverflow" target="_blank"
+href="{{ .Params.writerStackoverflow }}">
+<i class="fab fa-stack-overflow"
+title="stackoverflow icon"></i>
+</a>
+{{ else if $writer.stackoverflow }}
+<a class="stackoverflow" target="_blank"
+href="{{ $writer.stackoverflow }}">
+<i class="fab fa-stack-overflow"
+title="stackoverflow icon"></i>
+</a>
+{{end}}
+
+{{ if .Params.writerGithub }}
+<a class="github" target="_blank"
+href="{{ .Params.writerGithub }}">
+<i class="fab fa-github"
+title="github icon"></i>
+</a>
+{{ else if $writer.github }}
+<a class="github" target="_blank"
+href="{{ $writer.github }}">
+<i class="fab fa-github"
+title="github icon"></i>
+</a>
+{{end}}
+
+{{ if .Params.writerPinterest }}
+<a class="pinterest" target="_blank"
+href="{{ .Params.writerPinterest }}">
+<i class="fab fa-pinterest"
+title="pinterest icon"></i>
+</a>
+{{ else if $writer.pinterest }}
+<a class="pinterest" target="_blank"
+href="{{ $writer.pinterest }}">
+<i class="fab fa-pinterest"
+title="pinterest icon"></i>
+</a>
+{{end}}
+
+
+{{ else }}
+{{ with .Site.Params.social.facebook }}
+<a class="facebook" target="_blank"
+href="{{ . }}">
+<i class="fab fa-facebook-f"
+title="facebook icon"></i>
+</a>
+{{end}}
+
+{{ with .Site.Params.social.googleplus }}
+<a class="googleplus" target="_blank"
+href="{{ . }}">
+<i class="fab fa-google-plus-g"
+title="googleplus icon"></i>
+</a>
+{{end}}
+
+
+{{ with .Site.Params.social.twitter }}
+<a class="twitter" target="_blank"
+href="{{ . }}">
+<i class="fab fa-twitter-square"
+title="twitter icon"></i>
+</a>
+{{end}}
+{{ with .Site.Params.social.linkedin }}
+<a class="linkedin" target="_blank"
+href="{{ . }}">
+<i class="fab fa-linkedin"
+title="linkedin icon"></i>
+</a>
+{{end}}
+
+{{ with .Site.Params.social.email }}
+<a class="email" target="_blank"
+href="mailto:{{ . }}">
+<i class="fas fa-envelope"
+title="email icon"></i>
+</a>
+{{end}}
+
+{{ with .Site.Params.social.instagram }}
+<a class="instagram" target="_blank"
+href="{{ . }}">
+<i class="fab fa-instagram"
+title="instagram icon"></i>
+</a>
+{{end}}
+
+{{ with .Site.Params.social.stackoverflow }}
+<a class="stackoverflow" target="_blank"
+href="{{ . }}">
+<i class="fab fa-stack-overflow"
+title="stackoverflow icon"></i>
+</a>
+{{end}}
+
+{{ with .Site.Params.social.github }}
+<a class="github" target="_blank"
+href="{{ . }}">
+<i class="fab fa-github"
+title="github icon"></i>
+</a>
+{{end}}
+
+
+{{ with .Site.Params.social.pinterest }}
+<a class="pinterest" target="_blank"
+href="{{ . }}">
+<i class="fab fa-pinterest"
+title="pinterest icon"></i>
+</a>
+{{end}}
+{{ end }}
+
+
+</div>
+</div>
+{{ end }}
+</div>
+</div>
+
+<section id="comments" class="comments">
+  {{ template "_internal/disqus.html" . }}
+
+  <!--<div class="comments-number">
+  <h2>
+  4 Comments			</h2>
+</div>-->
+
+<!--
+<ol class="comment-list">
+<li class="comment even thread-even depth-1" id="li-comment-54">
+<article id="comment-54" class="comment">
+<div class="comment-author">
+<img alt='' src='https://secure.gravatar.com/avatar/39f7e57ccd31847dc1a4bfb2ee1cd596?s=72&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/39f7e57ccd31847dc1a4bfb2ee1cd596?s=144&#038;d=mm&#038;r=g 2x' class='avatar avatar-72 photo' height='72' width='72' />				<div>
+<div class="author-name"><a href='http://commenter.url' rel='external nofollow' class='url'>Commenter 2799</a></div>
+<div class="comment-date">April 18</div>
+<a rel='nofollow' class='comment-reply-link' href='https://www.competethemes.com/tracks-live-demo/this-is-a-standard-post/?replytocom=54#respond' onclick='return addComment.moveForm( "comment-54", "54", "respond", "1969" )' aria-label='Reply to Commenter 2799'>Reply</a>									</div>
+</div>
+<div class="comment-content">
+<p>sque lacus. Etiam consectetur rutrum justo.</p>
+<p>Duis facilisis. Aliquam sagittis. Proin consectetur egestas metus. Curabitur pellentesque posuere arcu. Integer lorem nulla, congue a, rhoncus nec, vestibulum a, ante. Mauris lobortis iaculis erat. Maecenas faucibus tincidunt dui. Cras accumsan vestibulum ligula. Morbi dapibus, lorem nec euismod pharetra, augue risus congue augue, molestie eleifend lacus magna nec magna. Mo</p>
+</div>
+</article>
+</li>
+
+</ol>-->
+
+
+</section>
+</div>
+
+<!--</div>--> <!-- .main -->
+
+
+{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,7 +27,7 @@
           <span class="date">{{ .Date.Format "02 January" }}</span>	<span> / </span>
 
           <span class="author">
-            <a target="_blank" href="{{ .Params.writerLink | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
+            <a target="_blank" href="{{ .Params.writer_link | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
           </span>
 
 
@@ -85,19 +85,19 @@
 <div class="author-meta">
 
   <div class="author">
-    {{ if and (isset .Params "writer") .Params.writerEmail }}
-      <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 .Params.writerEmail }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
+    {{ if and (isset .Params "writer") .Params.writer_email }}
+      <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 .Params.writer_email }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
     {{ else if and (isset .Params "writer") $writer.email }}
     <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 $writer.email }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
     {{ else }}
       <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 .Site.Params.email }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
     {{ end }}
     <span>
-      Written by:<a target="_blank" href="{{ .Params.writerLink | default .Site.Params.authorlink | absURL}}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a> </span>
+      Written by:<a target="_blank" href="{{ .Params.writer_link | default .Site.Params.authorlink | absURL}}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a> </span>
     </div>
     <div class="bio">
-      {{ if and (isset .Params "writer") .Params.writerBio }}
-        <p>{{ .Params.writerBio | default "" | safeHTML }}</p>
+      {{ if and (isset .Params "writer") .Params.writer_bio }}
+        <p>{{ .Params.writer_bio | default "" | safeHTML }}</p>
       {{ else if and (isset .Params "writer") $writer.bio }}
       {{ range $writer.bio  }}
       <p>{{ . | default "" | safeHTML }}</p>
@@ -108,9 +108,9 @@
       {{ end }}
       {{ end }}
   {{ if isset .Params "writer" }}
-    {{ if .Params.writerFacebook }}
+    {{ if .Params.writer_facebook }}
       <a class="facebook" target="_blank"
-      href="{{ .Params.writerFacebook }}">
+      href="{{ .Params.writer_facebook }}">
       <i class="fab fa-facebook-f"
       title="facebook icon"></i>
       </a>
@@ -122,9 +122,9 @@
     </a>
     {{end}}
 
-    {{ if .Params.writerGoogleplus }}
+    {{ if .Params.writer_googleplus }}
     <a class="googleplus" target="_blank"
-    href="{{ .Params.writerGoogleplus }}">
+    href="{{ .Params.writer_googleplus }}">
     <i class="fab fa-google-plus-g"
     title="googleplus icon"></i>
     </a>
@@ -136,9 +136,9 @@
     </a>
     {{end}}
 
-  {{ if .Params.writerTwitter }}
+  {{ if .Params.writer_twitter }}
     <a class="twitter" target="_blank"
-    href="{{ .Params.writerTwitter }}">
+    href="{{ .Params.writer_twitter }}">
     <i class="fab fa-twitter-square"
     title="twitter icon"></i>
   </a>
@@ -149,9 +149,9 @@
   title="twitter icon"></i>
 </a>
 {{end}}
-{{ if .Params.writerLinkedin }}
+{{ if .Params.writer_linkedin }}
 <a class="linkedin" target="_blank"
-href="{{ .Params.writerLinkedin }}">
+href="{{ .Params.writer_linkedin }}">
 <i class="fab fa-linkedin"
 title="linkedin icon"></i>
 </a>
@@ -163,9 +163,9 @@ title="linkedin icon"></i>
 </a>
 {{end}}
 
-{{ if .Params.writerEmail }}
+{{ if .Params.writer_email }}
 <a class="email" target="_blank"
-href="mailto:{{ .Params.writerEmail }}">
+href="mailto:{{ .Params.writer_email }}">
 <i class="fas fa-envelope"
 title="email icon"></i>
 </a>
@@ -177,9 +177,9 @@ title="email icon"></i>
 </a>
 {{end}}
 
-{{ if .Params.writerInstagram }}
+{{ if .Params.writer_instagram }}
 <a class="instagram" target="_blank"
-href="{{ .Params.writerInstagram }}">
+href="{{ .Params.writer_instagram }}">
 <i class="fab fa-instagram"
 title="instagram icon"></i>
 </a>
@@ -191,9 +191,9 @@ title="instagram icon"></i>
 </a>
 {{end}}
 
-{{ if .Params.writerStackoverflow }}
+{{ if .Params.writer_stackoverflow }}
 <a class="stackoverflow" target="_blank"
-href="{{ .Params.writerStackoverflow }}">
+href="{{ .Params.writer_stackoverflow }}">
 <i class="fab fa-stack-overflow"
 title="stackoverflow icon"></i>
 </a>
@@ -205,9 +205,9 @@ title="stackoverflow icon"></i>
 </a>
 {{end}}
 
-{{ if .Params.writerGithub }}
+{{ if .Params.writer_github }}
 <a class="github" target="_blank"
-href="{{ .Params.writerGithub }}">
+href="{{ .Params.writer_github }}">
 <i class="fab fa-github"
 title="github icon"></i>
 </a>
@@ -219,9 +219,9 @@ title="github icon"></i>
 </a>
 {{end}}
 
-{{ if .Params.writerPinterest }}
+{{ if .Params.writer_pinterest }}
 <a class="pinterest" target="_blank"
-href="{{ .Params.writerPinterest }}">
+href="{{ .Params.writer_pinterest }}">
 <i class="fab fa-pinterest"
 title="pinterest icon"></i>
 </a>

--- a/layouts/partials/category.html
+++ b/layouts/partials/category.html
@@ -1,0 +1,82 @@
+<div class="archive-header">
+	<h1>
+		Category: {{ .Title }}
+		{{ if .Site.Params.social.rss }}
+		<a href="{{ .RSSLink }}" data-animate-hover="pulse" class="in-page-rss" target="_blank">
+            <i class="fas fa-rss" title="rss"></i>
+            <span class="screen-reader-text">rss</span>
+		</a>
+		{{ end }}
+	</h1>
+</div>
+
+<h1 class="screen-reader-text">Posts</h1>
+<div id="loop-container" class="loop-container">
+  {{ range $index, $element := (where .Data.Pages "Section" "post").ByDate.Reverse }}
+
+	{{ $scratch := newScratch }}
+	{{ if .Site.Params.writers }}
+		{{ $scratch.Set "writer" (index .Site.Params.writers (lower .Params.writer) | default dict) }}
+	{{ else }}
+		{{ $scratch.Set "writer" .Site.Params.social | default dict }}
+	{{ end }}
+	{{ $writer := $scratch.Get "writer" }}
+
+		{{ if and (isset .Params "image") .Params.image }}
+			{{ if eq (mod $index 2) 0 }}
+				<div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-memories tag-normal-post tag-standard-2 excerpt zoom full-without-featured odd excerpt">
+			{{ else }}
+				<div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-memories tag-normal-post tag-standard-2 excerpt zoom full-without-featured even excerpt">
+			{{ end }}
+		{{ else }}
+			<div class="post type-post status-publish format-standard hentry category-standard category-travel excerpt zoom full-without-featured odd excerpt">
+		{{ end }}
+
+		{{ if and (isset .Params "image") .Params.image }}
+			<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image' {{if isset .Site.Params "usepostimgfolder"}}data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }}data-background="{{ .Params.image | absURL }}"{{ end }}></div></a>
+		{{ end }}
+
+				<div class="excerpt-container">
+					<div class="excerpt-meta">
+						<span class="date">{{ .Date.Format "02 January" }}</span>
+
+
+
+							{{ if and (isset .Site.Params "authorlink") .Site.Params.authorLink }}
+								{{ if and (isset .Site.Params "author") .Site.Params.author }}
+								<span> / </span>
+							<span class="author">
+							<a href="{{ $writer.link | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
+							</span>
+								{{ end }}
+							{{ else }}
+							<span class="author">
+							{{ .Params.writer | default .Site.Params.author }}
+							</span>
+							{{ end }}
+
+
+						 {{ range .Params.categories }}
+							<span> / </span>
+						<span class="category">
+							<a href="/categories/{{ . | urlize }}">{{ . }}</a>
+						</span>
+						{{ end }}
+					</div>
+							<div class='excerpt-header'>
+								<h2 class='excerpt-title'>
+									<a href="{{ .Permalink }} "> {{ .Title }} </a>
+								</h2>
+							</div>
+							<div class='excerpt-content'>
+								<article>
+									{{ .Summary }}
+
+									<div class="more-link-wrapper"><a class="more-link" href="{{ .Permalink }}">Read the post<span class="screen-reader-text">This is a Standard Post</span></a></div>
+									<div class="more-link-wrapper"><span><i class="clock icon"></i>{{ .ReadingTime }} min read</span></div>
+								</article>
+							</div>
+						</div>
+					</div>
+					{{ end }}
+				</div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,58 @@
+<div id="title-info" class="title-info">
+  <div id='site-title' class='site-title'>
+    <a href="{{ .Site.BaseURL | relLangURL }}">
+      {{ if (ne .Site.Params.Logo "" ) }}
+      <div class="logo-container">
+        <img  src="{{ .Site.Params.Logo | absURL }}" width="150">
+      </div>  
+      {{ end }}
+      {{ if and ( eq .Site.Params.Logo "" ) ( ne .Site.Title "" ) }}
+        {{ .Site.Title }} 
+      {{ end }}
+    </a>
+  </div>
+    
+  </div>
+  <button id="toggle-navigation" class="toggle-navigation">
+    <i class="fas fa-bars"></i>
+  </button>
+
+  <div id="menu-primary-tracks" class="menu-primary-tracks"></div>
+  <div id="menu-primary" class="menu-container menu-primary" role="navigation">
+    {{ with .Site.Params.Slogan }}
+    <p class="site-description">{{ . | default "" | safeHTML }}</p>
+    {{ end }}
+
+    <div class="menu">
+      <ul id="menu-primary-items" class="menu-primary-items">
+        {{ $page := . }}
+        {{ $categories := .Site.Taxonomies.categories }}
+        {{ range .Site.Menus.main }}
+        <li class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
+          <a href="{{ .URL | absURL }}">{{ .Name }}</a>
+          {{ if eq .Name "Categories" }}
+            <ul id="menu-secondary-items" class="sub-menu">
+                {{ range $name, $taxonomy := $categories }}
+                <li class="menu-item menu-item-type-taxonomy menu-item-object-category">
+                  <a href="{{ "/categories/" | relLangURL }}{{ $name | urlize }}">{{ $name }}</a>
+                </li>
+                {{ end }}
+        
+            </ul>
+          {{ end }}
+          {{ if .HasChildren }}
+          <ul class="sub-menu">
+            {{ range .Children }}
+            <li class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
+              <a href="{{ .URL | absURL }}">{{ .Name }}</a>
+            </li>
+            {{ end }}
+          </ul>
+          {{ end }}
+        </li>
+        {{ end }}
+        
+      </ul>
+    </div>
+
+  </div>

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -1,0 +1,70 @@
+<h1 class="screen-reader-text">Posts</h1>
+<div id="loop-container" class="loop-container">
+	{{ $paginator := .Paginate (where (where .Site.Pages "Type" "post").ByDate.Reverse "IsPage" true) }}
+	{{ range $index, $element := .Paginator.Pages }}
+  {{ $scratch := newScratch }}
+  {{ if .Site.Params.writers }}
+    {{ $scratch.Set "writer" (index .Site.Params.writers (lower .Params.writer) | default dict) }}
+  {{ else }}
+    {{ $scratch.Set "writer" (.Site.Params.social | default dict) }}
+  {{ end }}
+  {{ $writer := $scratch.Get "writer" }}
+	{{ if and (isset .Params "image") .Params.image }}
+	{{ if eq (mod $index 2) 0 }}
+	<div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-memories tag-normal-post tag-standard-2 excerpt zoom full-without-featured odd excerpt">
+		{{ else }}
+		<div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-memories tag-normal-post tag-standard-2 excerpt zoom full-without-featured even excerpt">
+			{{ end }}
+			{{ else }}
+
+			<div class="post type-post status-publish format-standard hentry category-standard category-travel excerpt zoom full-without-featured odd excerpt">
+
+				{{ end }}
+
+				{{ if and (isset .Params "image") .Params.image }}
+				<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image' {{if isset .Site.Params "usepostimgfolder"}}data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }}data-background="{{ .Params.image | absURL }}"{{ end }}></div></a>
+
+				{{ end }}
+				<div class="excerpt-container">
+					<div class="excerpt-meta">
+						<span class="date">{{ .Date.Format "02 January" }}</span>
+
+						{{ if and (isset .Site.Params "authorlink") .Site.Params.authorLink }}
+							{{ if and (isset .Site.Params "author") .Site.Params.author }}
+							<span> / </span>
+						<span class="author">
+						<a href="{{ $writer.link | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
+						</span>
+							{{ end }}
+						{{ else }}
+						<span class="author">
+						{{ .Params.writer | default .Site.Params.author }}
+						</span>
+						{{ end }}
+
+
+
+						{{ range .Params.categories }}
+						<span> / </span>
+						<span class="category">
+							<a href="/categories/{{ . | urlize }}">{{ . }}</a>
+						</span>
+						{{ end }}
+					</div>
+					<div class='excerpt-header'>
+						<h2 class='excerpt-title'>
+							<a href="{{ .Permalink }} "> {{ .Title }} </a>
+						</h2>
+					</div>
+					<div class='excerpt-content'>
+						<article>
+							{{ .Summary }}
+
+							<div class="more-link-wrapper"><a class="more-link" href="{{ .Permalink }}">Read the post<span class="screen-reader-text">This is a Standard Post</span></a></div>
+							<div class="more-link-wrapper"><span><i class="clock icon"></i>{{ .ReadingTime }} min read</span></div>
+						</article>
+					</div>
+				</div>
+			</div>
+			{{ end }}
+		</div>

--- a/layouts/partials/tag.html
+++ b/layouts/partials/tag.html
@@ -1,0 +1,71 @@
+<div class="archive-header">
+	<h1>
+		Tag: {{ .Title }}
+		{{ if .Site.Params.social.rss }}
+		<a href="{{ .RSSLink }}" data-animate-hover="pulse" class="in-page-rss" target="_blank">
+            <i class="fas fa-rss" title="rss"></i>
+            <span class="screen-reader-text">rss</span>
+		</a>
+		{{ end }}
+	</h1>
+</div>
+
+<h1 class="screen-reader-text">Posts</h1>
+<div id="loop-container" class="loop-container">
+  {{ range $index, $element := (where .Data.Pages "Section" "post").ByDate.Reverse }}
+	{{ if and (isset .Params "image") .Params.image }}
+	{{ if eq (mod $index 2) 0 }}
+	<div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-memories tag-normal-post tag-standard-2 excerpt zoom full-without-featured odd excerpt">
+		{{ else }}
+		<div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-memories tag-normal-post tag-standard-2 excerpt zoom full-without-featured even excerpt">
+			{{ end }}
+			{{ else }}
+
+			<div class="post type-post status-publish format-standard hentry category-standard category-travel excerpt zoom full-without-featured odd excerpt">
+
+				{{ end }}
+
+				{{ if and (isset .Params "image") .Params.image }}
+				<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image'   data-background="{{ .Params.image | absURL }}"></div></a>
+
+				{{ end }}
+
+				<div class="excerpt-container">
+					<div class="excerpt-meta">
+						<span class="date">{{ .Date.Format "02 January 2006" }}</span>	<span> / </span>
+
+						{{ if and (isset .Site.Params "author") .Site.Params.author }}
+
+						<span class="author">
+							{{ if and (isset .Site.Params "authorlink") .Site.Params.authorLink }}
+							<a href="{{ .Site.Params.authorLink | default "" | absURL }}" title="Posts by {{ .Site.Params.author | default "" }}" rel="author">{{ .Site.Params.author | default "" }}</a>
+							{{ else }}
+							{{ .Site.Params.author | default "" }}
+							{{ end }}
+						</span>
+						{{ end }}
+
+						 {{ range .Params.categories }}
+							<span> / </span>
+						<span class="category">
+							<a href="/categories/{{ . | urlize }}">{{ . }}</a>
+						</span>
+						{{ end }}
+					</div>
+							<div class='excerpt-header'>
+								<h2 class='excerpt-title'>
+									<a href="{{ .Permalink }} "> {{ .Title }} </a>
+								</h2>
+							</div>
+							<div class='excerpt-content'>
+								<article>
+									{{ .Summary }}
+
+									<div class="more-link-wrapper"><a class="more-link" href="{{ .Permalink }}">Read the post<span class="screen-reader-text">This is a Standard Post</span></a></div>
+									<div class="more-link-wrapper"><span><i class="clock icon"></i>{{ .ReadingTime }} min read</span></div>
+								</article>
+							</div>
+						</div>
+					</div>
+					{{ end }}
+				</div>

--- a/layouts/partials/topnavigation.html
+++ b/layouts/partials/topnavigation.html
@@ -1,0 +1,99 @@
+<div class='container'>
+
+  <ul class="social-media-icons">
+
+
+    {{ with .Site.Params.social.facebook }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="facebook" target="_blank">
+        <i class="fab fa-facebook-square" title="facebook"></i>
+        <span class="screen-reader-text">facebook</span>
+      </a>
+    </li>
+    {{end}}
+
+    {{ with .Site.Params.social.googleplus }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="gplus" target="_blank">
+        <i class="fab fa-google-plus-g" title="googleplus"></i>
+        <span class="screen-reader-text">googleplus</span>
+      </a>
+    </li>
+    {{end}}
+
+    {{ with .Site.Params.social.twitter }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="twitter" target="_blank">
+        <i class="fab fa-twitter-square" title="twitter"></i>
+        <span class="screen-reader-text">twitter</span>
+      </a>
+    </li>
+    {{end}}
+
+    {{ with .Site.Params.social.instagram }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="instagram" target="_blank">
+        <i class="fab fa-instagram" title="instagram"></i>
+        <span class="screen-reader-text">instagram</span>
+      </a>
+    </li>
+    {{end}}
+
+    {{ with .Site.Params.social.email }}
+    <li>
+      <a href="mailto:{{ . }}" data-animate-hover="pulse" class="email">
+        <i class="fas fa-envelope" title="email"></i>
+        <span class="screen-reader-text">email</span>
+      </a>
+    </li>
+    {{end}}
+
+    {{ with .Site.Params.social.linkedin }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="linkedin" target="_blank">
+        <i class="fab fa-linkedin-in" title="linkedin"></i>
+        <span class="screen-reader-text">linkedin</span>
+      </a>
+    </li>
+    {{end}}
+
+    {{ with .Site.Params.social.stackoverflow }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="stackoverflow" target="_blank">
+        <i class="fab fa-stack-overflow" title="stackoverflow"></i>
+        <span class="screen-reader-text">stackoverflow</span>
+      </a>
+    </li>
+    {{end}}
+
+
+    {{ with .Site.Params.social.github }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="github" target="_blank">
+        <i class="fab fa-github" title="github"></i>
+        <span class="screen-reader-text">github</span>
+      </a>
+    </li>
+    {{end}}
+
+
+    {{ with .Site.Params.social.pinterest }}
+    <li>
+      <a href="{{ . }}" data-animate-hover="pulse" class="pinterest" target="_blank">
+        <i class="fab fa-pinterest" title="pinterest"></i>
+        <span class="screen-reader-text">pinterest</span>
+      </a>
+    </li>
+    {{end}}
+
+    {{ if .Site.Params.social.rss }}
+    <li>
+      <a href="{{ .Site.RSSLink }}" data-animate-hover="pulse" class="rss" target="_blank">
+        <i class="fas fa-rss" title="rss"></i>
+        <span class="screen-reader-text">rss</span>
+      </a>
+    </li>
+    {{end}}
+
+
+  </ul></div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -5,3 +5,13 @@
     padding-top: 0.2em;
 }
 
+.menu-secondary-items:before {
+    content: none !important;
+}
+
+.author-meta .author a{
+    font-weight: 700 !important;    
+}
+.author-meta a:link, .author-meta a:visited{
+    color: #ffffff !important;
+}


### PR DESCRIPTION
-  Added Categories dropdown in main menu.
-  Added reading time support to the blog, category and tag list.
-  Custom style for the author name and info in the single blog post page.
-  Added support for  blog writer who is not added in the config.toml file and wants to provide information like website, email, twitter etc. A new blog writer can now provide the following information in the frontmatter:

```
writer_email = ""  
writer_bio = ""  
writer_facebook = ""  
writer_googleplus = ""  
writer_twitter = ""   
writerLinkedin = ""  
writer_instagram = ""  
writer_stackoverflow = ""  
writer_github = ""  
writer_pinterest = ""  
```